### PR TITLE
fix: replace incorrect `this.clone()` usages (#1878)

### DIFF
--- a/src/main/java/cn/nukkit/Player.java
+++ b/src/main/java/cn/nukkit/Player.java
@@ -947,9 +947,9 @@ public class Player extends EntityHuman implements CommandSender, ChunkLoader, I
                 } else {
                     if (this.getGamemode() != Player.SPECTATOR && (last.x != now.x || last.y != now.y || last.z != now.z)) {
                         if (this.isOnGround() && this.isGliding()) {
-                            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3().clone(), VibrationType.ELYTRA_GLIDE));
+                            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.ELYTRA_GLIDE));
                         } else if (this.isOnGround() && !(this.getSide(BlockFace.DOWN).getLevelBlock() instanceof BlockWool) && !this.isSneaking()) {
-                            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3().clone(), VibrationType.STEP));
+                            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.STEP));
                         } else if (this.isTouchingWater()) {
                             this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getLocation().clone(), VibrationType.SWIM));
                         }

--- a/src/main/java/cn/nukkit/block/BlockDoor.java
+++ b/src/main/java/cn/nukkit/block/BlockDoor.java
@@ -355,7 +355,7 @@ public abstract class BlockDoor extends BlockTransparent implements RedstoneComp
 
         playOpenCloseSound();
 
-        var source = this.clone().add(0.5, 0.5, 0.5);
+        var source = this.getVector3().add(0.5, 0.5, 0.5);
         VibrationEvent vibrationEvent = open ? new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_OPEN) : new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_CLOSE);
         this.level.getVibrationManager().callVibrationEvent(vibrationEvent);
         return true;

--- a/src/main/java/cn/nukkit/block/BlockFenceGate.java
+++ b/src/main/java/cn/nukkit/block/BlockFenceGate.java
@@ -222,7 +222,7 @@ public class BlockFenceGate extends BlockTransparent implements RedstoneComponen
 
         playOpenCloseSound();
 
-        var source = this.clone().add(0.5, 0.5, 0.5);
+        var source = this.getVector3().add(0.5, 0.5, 0.5);
         VibrationEvent vibrationEvent = open ? new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_OPEN) : new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_CLOSE);
         this.level.getVibrationManager().callVibrationEvent(vibrationEvent);
         return true;

--- a/src/main/java/cn/nukkit/block/BlockTrapdoor.java
+++ b/src/main/java/cn/nukkit/block/BlockTrapdoor.java
@@ -263,7 +263,7 @@ public class BlockTrapdoor extends BlockTransparent implements RedstoneComponent
 
         playOpenCloseSound();
 
-        var source = this.clone().add(0.5, 0.5, 0.5);
+        var source = this.getVector3().add(0.5, 0.5, 0.5);
         VibrationEvent vibrationEvent = open ? new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_OPEN) : new VibrationEvent(player != null ? player : this, source, VibrationType.BLOCK_CLOSE);
         this.level.getVibrationManager().callVibrationEvent(vibrationEvent);
         return true;

--- a/src/main/java/cn/nukkit/blockentity/BlockEntityCalibratedSculkSensor.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntityCalibratedSculkSensor.java
@@ -53,7 +53,7 @@ public class BlockEntityCalibratedSculkSensor extends BlockEntity implements Vib
 
     @Override
     public Position getListenerVector() {
-        return this.clone().setLevel(this.level).floor().add(0.5f, 0.5f, 0.5f);
+        return this.getPosition().setLevel(this.level).floor().add(0.5f, 0.5f, 0.5f);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/blockentity/BlockEntitySculkSensor.java
+++ b/src/main/java/cn/nukkit/blockentity/BlockEntitySculkSensor.java
@@ -57,7 +57,7 @@ public class BlockEntitySculkSensor extends BlockEntity implements VibrationList
 
     @Override
     public Position getListenerVector() {
-        return this.clone().setLevel(this.level).floor().add(0.5f, 0.5f, 0.5f);
+        return this.getPosition().setLevel(this.level).floor().add(0.5f, 0.5f, 0.5f);
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/Entity.java
+++ b/src/main/java/cn/nukkit/entity/Entity.java
@@ -1183,7 +1183,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         setHealth(newHealth);
 
         if (!(this instanceof EntityArmorStand)) {
-            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(attacker, this.clone(), VibrationType.ENTITY_DAMAGE));
+            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(attacker, this.getVector3(), VibrationType.ENTITY_DAMAGE));
         }
 
         return true;
@@ -1520,9 +1520,9 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
         if (diffPosition > 0.0001 || diffRotation > 1.0) { //0.2 ** 2, 1.5 ** 2
             if (diffPosition > 0.0001) {
                 if (this.isOnGround()) {
-                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this instanceof EntityProjectile projectile ? projectile.shootingEntity : this, this.clone(), VibrationType.STEP));
+                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this instanceof EntityProjectile projectile ? projectile.shootingEntity : this, this.getVector3(), VibrationType.STEP));
                 } else if (this.isTouchingWater()) {
-                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this instanceof EntityProjectile projectile ? projectile.shootingEntity : this, this.clone(), VibrationType.SWIM));
+                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this instanceof EntityProjectile projectile ? projectile.shootingEntity : this, this.getVector3(), VibrationType.SWIM));
                 }
             }
 
@@ -1875,7 +1875,7 @@ public abstract class Entity extends Location implements Metadatable, EntityID, 
                 if (!this.isSneaking()) {
                     if (!(this instanceof EntityItem item) ||
                             !ItemTags.getTagSet(item.getIdentifier()).contains(ItemTags.WOOL)) {
-                        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.HIT_GROUND));
+                        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.HIT_GROUND));
                     }
                 }
                 this.attack(new EntityDamageEvent(this, DamageCause.FALL, damage));

--- a/src/main/java/cn/nukkit/entity/EntityIntelligentHuman.java
+++ b/src/main/java/cn/nukkit/entity/EntityIntelligentHuman.java
@@ -158,9 +158,9 @@ public class EntityIntelligentHuman extends EntityIntelligent implements EntityI
         if (diffPosition > 0.0001 || diffRotation > 1.0) { //0.2 ** 2, 1.5 ** 2
             if (diffPosition > 0.0001) {
                 if (this.isOnGround()) {
-                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.STEP));
+                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.STEP));
                 } else if (this.isTouchingWater()) {
-                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.SWIM));
+                    this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.SWIM));
                 }
             }
             this.broadcastMovement(false);

--- a/src/main/java/cn/nukkit/entity/item/EntityArmorStand.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityArmorStand.java
@@ -370,7 +370,7 @@ public class EntityArmorStand extends Entity implements EntityInventoryHolder, E
         level.addSound(this, Sound.MOB_ARMOR_STAND_BREAK);
 
         //todo: initiator should be a entity who kill it but not itself
-        level.getVibrationManager().callVibrationEvent(new VibrationEvent(this.getLastDamageCause() instanceof EntityDamageByEntityEvent byEntity ? byEntity.getDamager() : this, this.clone(), VibrationType.ENTITY_DIE));
+        level.getVibrationManager().callVibrationEvent(new VibrationEvent(this.getLastDamageCause() instanceof EntityDamageByEntityEvent byEntity ? byEntity.getDamager() : this, this.getVector3(), VibrationType.ENTITY_DIE));
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/item/EntityTnt.java
+++ b/src/main/java/cn/nukkit/entity/item/EntityTnt.java
@@ -173,7 +173,7 @@ public class EntityTnt extends Entity implements EntityExplosive {
             explosion.explodeA();
         }
         explosion.explodeB();
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.EXPLODE));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.EXPLODE));
     }
 
     public Entity getSource() {

--- a/src/main/java/cn/nukkit/entity/mob/EntityWarden.java
+++ b/src/main/java/cn/nukkit/entity/mob/EntityWarden.java
@@ -190,7 +190,7 @@ public class EntityWarden extends EntityMob implements EntityWalkable, Vibration
 
     @Override
     public Vector3 getListenerVector() {
-        return this.clone();
+        return this.getVector3();
     }
 
     @Override

--- a/src/main/java/cn/nukkit/entity/passive/EntityMooshroom.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntityMooshroom.java
@@ -121,7 +121,7 @@ public class EntityMooshroom extends EntityAnimal implements EntityWalkable {
             cow.setPosition(this);
             cow.setRotation(this.yaw, this.pitch);
             cow.spawnToAll();
-            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this.clone(), this.getPosition(), VibrationType.SHEAR));
+            this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.SHEAR));
             return true;
         } else if (item.getId() == Item.BUCKET && item.getDamage() == 0) {
             item.count--;

--- a/src/main/java/cn/nukkit/entity/passive/EntitySheep.java
+++ b/src/main/java/cn/nukkit/entity/passive/EntitySheep.java
@@ -179,7 +179,7 @@ public class EntitySheep extends EntityAnimal implements EntityWalkable, EntityS
         this.level.dropItem(this, woolItem);
 
         level.addSound(this, Sound.MOB_SHEEP_SHEAR);
-        level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.SHEAR));
+        level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.SHEAR));
         return true;
     }
 

--- a/src/main/java/cn/nukkit/entity/projectile/EntityFireball.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityFireball.java
@@ -58,7 +58,7 @@ public class EntityFireball extends EntitySmallFireball implements EntityExplosi
 
     @Override
     protected void onCollideWithBlock(Position position, Vector3 motion) {
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.PROJECTILE_LAND));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.PROJECTILE_LAND));
         boolean affect = false;
         for (Block collisionBlock : level.getCollisionBlocks(getBoundingBox().grow(0.1, 0.1, 0.1)))
             affect = onCollideWithBlock(position, motion, collisionBlock);

--- a/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityProjectile.java
@@ -88,7 +88,7 @@ public abstract class EntityProjectile extends Entity {
             return;
         }
 
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.PROJECTILE_LAND));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.PROJECTILE_LAND));
 
         float damage = this.getResultDamage(entity);
 
@@ -273,7 +273,7 @@ public abstract class EntityProjectile extends Entity {
     }
 
     protected void onCollideWithBlock(Position position, Vector3 motion) {
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.PROJECTILE_LAND));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.PROJECTILE_LAND));
         for (Block collisionBlock : level.getCollisionBlocks(getBoundingBox().grow(0.1, 0.1, 0.1))) {
             onCollideWithBlock(position, motion, collisionBlock);
         }
@@ -299,6 +299,6 @@ public abstract class EntityProjectile extends Entity {
     public void spawnToAll() {
         super.spawnToAll();
         //vibration: minecraft:projectile_shoot
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this.shootingEntity, this.clone(), VibrationType.PROJECTILE_SHOOT));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this.shootingEntity, this.getVector3(), VibrationType.PROJECTILE_SHOOT));
     }
 }

--- a/src/main/java/cn/nukkit/entity/projectile/EntitySmallFireball.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntitySmallFireball.java
@@ -72,7 +72,7 @@ public class EntitySmallFireball extends EntityProjectile {
         ProjectileHitEvent projectileHitEvent = new ProjectileHitEvent(this, MovingObjectPosition.fromEntity(entity));
         this.server.getPluginManager().callEvent(projectileHitEvent);
         if (projectileHitEvent.isCancelled()) return;
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.PROJECTILE_LAND));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.PROJECTILE_LAND));
         var damage = this.getResultDamage(entity);
         EntityDamageEvent ev = new EntityDamageByEntityEvent(this, entity, EntityDamageEvent.DamageCause.PROJECTILE, damage);
         if (entity.attack(ev)) {
@@ -89,7 +89,7 @@ public class EntitySmallFireball extends EntityProjectile {
 
     @Override
     protected void onCollideWithBlock(Position position, Vector3 motion) {
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.PROJECTILE_LAND));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.PROJECTILE_LAND));
         var affect = false;
         for (Block collisionBlock : level.getCollisionBlocks(getBoundingBox().grow(0.1, 0.1, 0.1)))
             affect = onCollideWithBlock(position, motion, collisionBlock);

--- a/src/main/java/cn/nukkit/entity/projectile/EntityWitherSkull.java
+++ b/src/main/java/cn/nukkit/entity/projectile/EntityWitherSkull.java
@@ -74,7 +74,7 @@ public class EntityWitherSkull extends EntityProjectile implements EntityExplosi
 
     @Override
     protected void onCollideWithBlock(Position position, Vector3 motion) {
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.PROJECTILE_LAND));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.PROJECTILE_LAND));
         boolean affect = false;
         for (Block collisionBlock : level.getCollisionBlocks(getBoundingBox().grow(0.1, 0.1, 0.1)))
             affect = onCollideWithBlock(position, motion, collisionBlock);

--- a/src/main/java/cn/nukkit/entity/weather/EntityLightningBolt.java
+++ b/src/main/java/cn/nukkit/entity/weather/EntityLightningBolt.java
@@ -229,7 +229,7 @@ public class EntityLightningBolt extends Entity implements EntityLightningStrike
 
     @Override
     public void spawnToAll() {
-        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.clone(), VibrationType.LIGHTNING_STRIKE));
+        this.level.getVibrationManager().callVibrationEvent(new VibrationEvent(this, this.getVector3(), VibrationType.LIGHTNING_STRIKE));
         super.spawnToAll();
     }
 }


### PR DESCRIPTION
* fix: Player::clone()
- this.clone() --> this.getVector3() in Entity
- this.getVector3().clone() --> this.getVector3() in Player

* fix:
- remove Entity::clone usage in VibrationEvents
- replace clone() with getVector3() or equivalent where required